### PR TITLE
return new_playlist information in /createNewPlaylist response

### DIFF
--- a/app/api/spotify/createNewPlaylist/route.js
+++ b/app/api/spotify/createNewPlaylist/route.js
@@ -5,7 +5,7 @@ import { createNewPlaylist } from "@/lib/spotify/createNewPlaylist";
 export async function POST(request) {
     const { refresh_token } = await request.json();
     const access_token = await getAccessToken(refresh_token);
-    const { playlist_id, snapshot_id } = await createNewPlaylist(access_token);
+    const { playlist_id, snapshot_id, new_playlist } = await createNewPlaylist(access_token);
 
-    return NextResponse.json({ playlist_id, snapshot_id })
+    return NextResponse.json({ playlist_id, snapshot_id, new_playlist })
 }

--- a/lib/spotify/createNewPlaylist.js
+++ b/lib/spotify/createNewPlaylist.js
@@ -5,5 +5,5 @@ export const createNewPlaylist = async (access_token) => {
     const newPlaylist = await createNewDefualtPlaylist(access_token);
     const response = await addDefaultSongsToPlaylists(newPlaylist.id, access_token);
 
-    return { playlist_id: newPlaylist.id, snapshot_id: response }
+    return { playlist_id: newPlaylist.id, snapshot_id: response, new_playlist: newPlaylist }
 }


### PR DESCRIPTION
When calling the `api/spotify/createNewPlaylist` endpoint the response used to be `snapshot_id` and `playlist_id`. Now it also retruns the whole JSON with the `newPlaylist` information
Give it a look:

![image](https://github.com/Matdweb/Spotiy-Playlist-Retriever/assets/110640534/5fdee50f-3a71-4a46-ae46-73e9fee91712)

Here, we are printing the response to `api/spotify/createNewPlaylist`
